### PR TITLE
Additional use of ProducesResponseTypeAttribue

### DIFF
--- a/StargateApi/Controllers/AstronautDutyController.cs
+++ b/StargateApi/Controllers/AstronautDutyController.cs
@@ -2,7 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using StargateAPI.Business.Commands;
 using StargateAPI.Business.Queries;
-using System.Net;
+using StargateAPI.Utilities;
 
 namespace StargateAPI.Controllers;
 
@@ -13,16 +13,12 @@ public class AstronautDutyController(IMediator mediator) : ControllerBase
     private readonly IMediator _mediator = mediator;
 
     [HttpGet("{name}")]
-    [ProducesResponseType<GetAstronautDutiesByNameResult>(statusCode: (int)HttpStatusCode.OK)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
+    [Ok<GetAstronautDutiesByNameResult>, NotFound]
     public Task<GetAstronautDutiesByNameResult> GetAstronautDutiesByName(string name) =>
         _mediator.Send(new GetAstronautDutiesByName(name: name));
 
     [HttpPost]
-    [ProducesResponseType<CreateAstronautDutyResult>(statusCode: (int)HttpStatusCode.Created)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
+    [Created<CreateAstronautDutyResult>, BadRequest, NotFound, Conflict]
     public async Task<IActionResult> CreateAstronautDuty([FromBody] CreateAstronautDuty request) 
     {
         var createAstronautDutyResult = await _mediator.Send(request);

--- a/StargateApi/Controllers/AstronautDutyController.cs
+++ b/StargateApi/Controllers/AstronautDutyController.cs
@@ -20,6 +20,7 @@ public class AstronautDutyController(IMediator mediator) : ControllerBase
 
     [HttpPost]
     [ProducesResponseType<CreateAstronautDutyResult>(statusCode: (int)HttpStatusCode.Created)]
+    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
     [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
     public async Task<IActionResult> CreateAstronautDuty([FromBody] CreateAstronautDuty request) 

--- a/StargateApi/Controllers/PersonController.cs
+++ b/StargateApi/Controllers/PersonController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using StargateAPI.Business.Commands;
 using StargateAPI.Business.Dtos;
 using StargateAPI.Business.Queries;
-using System.Net;
+using StargateAPI.Utilities;
 
 namespace StargateAPI.Controllers;
 
@@ -14,20 +14,17 @@ public class PersonController(IMediator mediator) : ControllerBase
     private readonly IMediator _mediator = mediator;
 
     [HttpGet]
-    [ProducesResponseType<GetPeopleResult>(statusCode: (int)HttpStatusCode.OK)]
+    [Ok<GetPeopleResult>]
     public Task<GetPeopleResult> GetPeople() =>
         _mediator.Send(new GetPeople());
 
     [HttpGet("{name}")]
-    [ProducesResponseType<GetPersonByNameResult>(statusCode: (int)HttpStatusCode.OK)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
+    [Ok<GetPersonByNameResult>, NotFound]
     public Task<GetPersonByNameResult> GetPersonByName(string name) =>
         _mediator.Send(new GetPersonByName(name: name));
 
     [HttpPost]
-    [ProducesResponseType<CreatePersonResult>(statusCode: (int)HttpStatusCode.Created)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
+    [Created<CreatePersonResult>, BadRequest, Conflict]
     public async Task<CreatedResult> CreatePerson([FromBody] CreatePerson request) 
     {
         var createPersonResult = await _mediator.Send(request);
@@ -37,10 +34,7 @@ public class PersonController(IMediator mediator) : ControllerBase
     }
 
     [HttpPut("{name}")]
-    [ProducesResponseType<UpdatePersonResult>(statusCode: (int)HttpStatusCode.OK)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
-    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
+    [Ok<UpdatePersonResult>, BadRequest, NotFound, Conflict]
     public Task<UpdatePersonResult> UpdatePerson(string name, [FromBody] UpdatePersonInput input) =>
         _mediator.Send(new UpdatePerson
         {

--- a/StargateApi/Controllers/PersonController.cs
+++ b/StargateApi/Controllers/PersonController.cs
@@ -26,6 +26,7 @@ public class PersonController(IMediator mediator) : ControllerBase
 
     [HttpPost]
     [ProducesResponseType<CreatePersonResult>(statusCode: (int)HttpStatusCode.Created)]
+    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
     public async Task<CreatedResult> CreatePerson([FromBody] CreatePerson request) 
     {
@@ -37,6 +38,7 @@ public class PersonController(IMediator mediator) : ControllerBase
 
     [HttpPut("{name}")]
     [ProducesResponseType<UpdatePersonResult>(statusCode: (int)HttpStatusCode.OK)]
+    [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.BadRequest)]
     [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.NotFound)]
     [ProducesResponseType<ProblemDetails>(statusCode: (int)HttpStatusCode.Conflict)]
     public Task<UpdatePersonResult> UpdatePerson(string name, [FromBody] UpdatePersonInput input) =>

--- a/StargateApi/Utilities/ResponseTypeAttributes.cs
+++ b/StargateApi/Utilities/ResponseTypeAttributes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using System.Net;
+
+namespace StargateAPI.Utilities;
+
+public class OkAttribute<TResponse>()
+    : ProducesResponseTypeAttribute<TResponse>(
+        statusCode: (int)HttpStatusCode.OK)
+{}
+
+public class CreatedAttribute<TResponse>()
+    : ProducesResponseTypeAttribute<TResponse>(
+        statusCode: (int) HttpStatusCode.Created)
+{}
+
+public class NotFound()
+    : ProducesResponseTypeAttribute<ProblemDetails>(
+        statusCode: (int)HttpStatusCode.NotFound)
+{ }
+
+public class BadRequest()
+    : ProducesResponseTypeAttribute<ProblemDetails>(
+        statusCode: (int)HttpStatusCode.BadRequest)
+{ }
+
+public class Conflict()
+    : ProducesResponseTypeAttribute<ProblemDetails>(
+        statusCode: (int)HttpStatusCode.Conflict)
+{ }


### PR DESCRIPTION
## Purposes
- Add missing BadRequest response types on applicable endpoints.
- Create and use concise aliases/wrappers for the few needed variations of `ProducesResponseTypeAttibute`.